### PR TITLE
Rewrite obsolete module usage to new one

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,8 @@ install:
 
 installdeps:
 	# .deb/apt-get based distros
-	if test -x "$(APT_GET)"; then $(APT_GET) -y install perl-base perl-modules libnet-ip-perl libnet-dns-perl libio-socket-inet6-perl iproute2 iptables tayga; fi
+	if test -x "$(APT_GET)"; then $(APT_GET) -y install perl-base perl-modules libnet-ip-perl libnet-dns-perl libio-socket-ip-perl iproute2 iptables tayga; fi
 	# .rpm/DNF/YUM-based distros
-	if test -x "$(DNF_OR_YUM)"; then $(DNF_OR_YUM) -y install perl perl-Net-IP perl-Net-DNS perl-IO-Socket-INET6 perl-File-Temp iproute iptables; fi
+	if test -x "$(DNF_OR_YUM)"; then $(DNF_OR_YUM) -y install perl perl-Net-IP perl-Net-DNS perl-IO-Socket-IP perl-File-Temp iproute iptables; fi
 	# If necessary, try to install the TAYGA .rpm using dnf/yum. It is unfortunately not available in all .rpm based distros (in particular CentOS/RHEL).
 	if test -x "$(DNF_OR_YUM)" && test ! -x "$(TAYGA)"; then $(DNF_OR_YUM) -y install tayga || echo "ERROR: Failed to install TAYGA using dnf/yum, the package is probably not included in your distro. Try enabling the EPEL repo <URL: https://fedoraproject.org/wiki/EPEL> and try again, or install TAYGA <URL: http://www.litech.org/tayga> directly from source."; exit 1; fi

--- a/clatd
+++ b/clatd
@@ -328,7 +328,7 @@ sub find_rfc7050_wka {
 sub get_plat_prefix {
   p("Performing DNS64-based PLAT prefix discovery (cf. RFC 7050)");
 
-  require IO::Socket::INET6; # needed by Net::DNS for querying IPv6 servers
+  require IO::Socket::IP; # needed by Net::DNS for querying IPv6 servers
   require Net::DNS;
 
   my @dns64_servers = split(",", cfg("dns64-servers") || "");


### PR DESCRIPTION
Perl module IO::Socket::INET6 is obsolete and recomended one is IO::Socket::IP, which has compatibility to old one.

btw: Net::DNS was rewrited to use IO::Socket::IP.