### PR TITLE
SystemD service: ensure service starts after DNS queries (e.g. ipv4only.arpa) can be resolved.

### DIFF
--- a/scripts/clatd.systemd
+++ b/scripts/clatd.systemd
@@ -12,6 +12,7 @@
 Description=464XLAT CLAT daemon
 Documentation=man:clatd(8)
 After=network-online.target
+After=nss-lookup.target
 StartLimitIntervalSec=0
 
 [Service]


### PR DESCRIPTION
Following on from <https://github.com/toreanderson/clatd/issues/42#issuecomment-2576251389>:

> You may like to add the following `Before` and `Wants` lines to the default SystemD unit file:
> 
> ```
> [Unit]
> Description=464XLAT CLAT daemon
> Documentation=man:clatd(8)
> After=network-online.target
> Before=nss-lookup.target
> Wants=network-online.target nss-lookup.target
> StartLimitIntervalSec=0
> ```
> 
> This should ensure that clatd only starts if a DNS server is reachable; it has been working reliably for me. Otherwise, if clatd is enabled to start on boot, then if/when it tries to determine the PLAT prefix by querying ipv4only.arpa, the following is likely to happen:
> 
> ```
> 20:08:57 clatd-test clatd[485]: Performing DNS64-based PLAT prefix discovery (cf. RFC 7050)
> 20:10:12 clatd-test clatd[485]: No PLAT prefix could be discovered. Your ISP probably doesn't provide NAT64/DNS64 PLAT service. Exiting.
> 20:10:12 clatd-test systemd[1]: clatd.service: Deactivated successfully.
> ```
> 
> Manually restarting the service after this timeout gets things working again, but we'd rather start the service at the right time. Alternatively/additionally, we might consider having an extra configuration option to treat lack of discovery of a PLAT prefix not as "NAT64 is not available", but as an error, and then the SystemD unit could use `Restart=on-failure`. This would be useful for servers and other fixed-location machines that are known to be in IPv6-only networks where NAT64 should always be available.