### PR TITLE
Decrease priority number for prerouting chain

### DIFF
--- a/clatd
+++ b/clatd
@@ -1055,13 +1055,13 @@ if(cfgint("ctmark")) {
     or err("'nft -f-' failed to execute");
   print $fd "add table ip6 clatd\n";
   print $fd "add chain ip6 clatd prerouting ",
-            "{ type filter hook prerouting priority 0; }\n";
+            "{ type filter hook prerouting priority mangle; }\n";
   print $fd "add rule ip6 clatd prerouting",
             " iif ", cfg("clat-dev"),
             " ip6 saddr ", cfg("clat-v6-addr"),
             " ip6 daddr ", cfg("plat-prefix"),
             " ct mark set ", cfgint("ctmark"),
-            # set meta mark as well, to placate firewalld's IPv6_rpfilter
+            # set meta mark as well, to placate firewalld's IPv6_rpfilter and NixOS' rpfilter rules
             " meta mark set ", cfgint("ctmark"), " counter\n";
   print $fd "add rule ip6 clatd prerouting",
             " iif ", cfg("plat-dev"),


### PR DESCRIPTION
This allows for clatd to work OOTB on distros shipping firewalls that do reverse-path filtering based on conntrack marks in the "mangle" priority (i.e. -150).