### PR TITLE
Update service status to better reflect 'no PLAT' state

### DIFF
--- a/clatd
+++ b/clatd
@@ -392,7 +392,7 @@ sub get_plat_prefix_from_dns64 {
     p("No PLAT prefix could be discovered, using fallback");
     return $CFG{"plat-fallback-prefix"};
   } else {
-    p("No PLAT prefix could be discovered. Your ISP probably doesn't provide",
+    p("No PLAT prefix could be discovered. Your connection probably doesn't provide",
       " NAT64/DNS64 PLAT service. Exiting.");
     cleanup_and_exit(0);
   }


### PR DESCRIPTION
When checking the service status of `clatd` in systemctl, if no NAT64 prefix is identified, clatd prints _"No PLAT prefix could be discovered. Your ISP probably doesn't provide NAT64/DNS64 PLAT service. Exiting."_.
I understand the point of it but there are cases that a maintainer (i.e. yours truly) deploys a local PLAT on LAN for an IPv6-mostly network despite the ISP who this network upstreams traffic to the Internet has it or not. So, my intention is to reflect a better status, stating that the current connection, regardless of the medium (Ethernet, Wi-Fi, WWAN, mobile tethering a.k.a. hotspot), has no PLAT available instead of blaming the ISP only.